### PR TITLE
nws: remove iptables chain FORWARD_vifX.* on domX shutdown/destroy

### DIFF
--- a/nws/NetworkFirewall.hs
+++ b/nws/NetworkFirewall.hs
@@ -105,6 +105,7 @@ cleanupFirewallRules vif bridgeI = configGetBridgeFiltering >>= \x -> when (x) $
     cleanupVifOutRules bridge
     removeChain vifChainOut
     removeChain vifChainIn
+    removeChain vifChain
 
     where
         vifIfaceIn="--physdev-in " ++ vif


### PR DESCRIPTION
OXT-949

Signed-off-by: Jed <lejosnej@ainfosec.com>