### PR TITLE
OXT-1437: network-slave: Forward 802.1x packets on brbridged

### DIFF
--- a/nws/NetworkInterface.hs
+++ b/nws/NetworkInterface.hs
@@ -434,7 +434,7 @@ configureSharedNetwork brshared interface outputIf nwType subnetRange = do
 configureBridgedNetwork :: String -> String -> String -> String -> IO ()
 configureBridgedNetwork bridge interface nwType nwMac = do
     debug $ printf "configureBridgedNetwork : %s %s %s %s" bridge interface nwType nwMac
-    checkAndAddBridge bridge
+    checkAndAddBridgeFwd bridge
     disableReversePathFilter bridge
     readProcessOrDie "ifconfig" [interface, "0.0.0.0", "up", "promisc"] []
     ethMac <- if (null nwMac)


### PR DESCRIPTION
The break-8021d patch was supposed to support passing 802.1x PAE frames
from the guest, through stubdom and NDVM, to physical hardware.
break-8021d no longer worked properly, so it was dropped in favor of the
upstream group_fwd_mask.  NDVM need to be configured as well to pass
the frames, so do so when creating brbridged.

802.1x forwarding only makes sense on brbridged since otherwise Ndvm
itself will try to access the network.  Also, transparent bridging
should be used since otherwise the other bridges could send out over the
NIC.  And given that, it can only really be used with a single guest
running.

We could echo 0xfff8 into the sysfs node, but then network-slave would
need SELinux permission to all of sysfs_t.  Instead create the bridge
with `ip link add` since that lets us set group_fwd_mask at creation
time.  Setting it after the fact is not exposed.  At the same time we
can disable stp with stp_state 0 and disable the forwarding delay.  `ip`
already has appropriate SELinux permissions.

OXT-1437

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>