### PR TITLE
dnsmasq-script: Use db-rm-dom0

### DIFF
--- a/dnsmasq-script-template
+++ b/dnsmasq-script-template
@@ -30,7 +30,7 @@ update_lease() {
 }
 remove_lease() {
 	logger "$SCRIPTNAME: removing lease for $1"
-	db-remove-dom0 "$DOMSTORE_PATH/$1"
+	db-rm-dom0 "$DOMSTORE_PATH/$1"
 }
 
 logger "$SCRIPTNAME: invoked with: $@"


### PR DESCRIPTION
db-remove-dom0 doesn't exist - use the correct command.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>