### PR TITLE
[argo] Replace v4v with argo

### DIFF
--- a/nwd/nwd.initscript
+++ b/nwd/nwd.initscript
@@ -30,7 +30,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 do_start()
 {
         echo "Starting network daemon"
-        V4V_CLIENT_PORT_ADDEND=10000 start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- +RTS -F1 -G1
+        ARGO_CLIENT_PORT_ADDEND=10000 start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- +RTS -F1 -G1
 }
 
 do_stop()


### PR DESCRIPTION
Replace single instance of V4V_CLIENT_PORT_ADDEND
with ARGO_CLIENT_PORT_ADDEND.

OXT-1464

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>