### PR TITLE
OXT-1772: Use system call instead of spawning a shell

### DIFF
--- a/nwd/Main.hs
+++ b/nwd/Main.hs
@@ -157,7 +157,7 @@ configureDom0IP = do
 	 ExitSuccess -> do debug "Configure IP address for dom0 interface"
                            pid <- strip <$> fromMaybe "" <$> maybeGetContents udhcpcPidFile
                            unless (null pid) $ void $ system $ "kill " ++ pid 
-			   spawnShell $ printf "udhcpc -b -i eth0 -p %s" udhcpcPidFile
+			   system $ printf "udhcpc -b -i eth0 -p %s" udhcpcPidFile
 	 otherwise -> do threadDelay 1000
 			 configureDom0IP
     where udhcpcPidFile = "/var/run/udhcpc.pid"


### PR DESCRIPTION
'spawnShell' used to run udhcpc on eth0 interface in dom0 fails occasionally.
This leaves eth0 with no ip address.

My suspicion is that the phenomena of 'opening a shell and running a
process will result in termination of the process when the shell is closed'
is in effect when spawnShell is used here, because after few attempts
udhcpc forks a child process when it fails to get an ip address before
returning to the shell invoking it.

Using 'system' instead has no failures, system is a system call which
achieves the purpose of executing a shell command without creating a shell.

This commit also fixes the issue of having to run udhcpc on eth0 when
ethernet cable is plugged-in after system boot.

OXT-1772

Signed-off-by: Mahantesh Salimath <salimathm@ainfosec.com>