### PR TITLE
RFC: nws, nwd: Use rpc-autogen bindings module

### DIFF
--- a/nwd/network-daemon.cabal
+++ b/nwd/network-daemon.cabal
@@ -28,7 +28,8 @@ Executable network-daemon
     xchxenstore,
     xchdb,
     xch-rpc,
-    directory
+    directory,
+    rpc-autogen
   Main-Is: Main.hs
   GHC-Options -O2 -fwarn-incomplete-patterns -dynamic -threaded
 

--- a/nws/network-slave.cabal
+++ b/nws/network-slave.cabal
@@ -27,7 +27,8 @@ Executable network-slave
     xchutils,
     xchxenstore,
     xch-rpc,
-    directory
+    directory,
+    rpc-autogen
   Main-Is: Main.hs
   GHC-Options -O2 -fwarn-incomplete-patterns -dynamic -threaded
 


### PR DESCRIPTION
dbus-gen generates a set of bindings for the currently supported API. Use the built module instead of relying on generating the bindings from the IDL in the source tree.