### PR TITLE
OXT-1824 [network-daemon] Close FDs when ndvm is stopped

### DIFF
--- a/nwd/network-daemon.cabal
+++ b/nwd/network-daemon.cabal
@@ -28,6 +28,7 @@ Executable network-daemon
     xchxenstore,
     xchdb,
     xch-rpc,
+    udbus,
     directory
   Main-Is: Main.hs
   GHC-Options -O2 -fwarn-incomplete-patterns -dynamic -threaded


### PR DESCRIPTION
  When an NDVM is shutdown or restarted, a /dev/argo_stream FD
  remains open for the network-daemon process. Because they are
  never cleaned up, network-daemon will continue to leak FDs until
  it causes a strain on the system.

  This commit explicitly calls into the lower level DBus haskell
  bindings to close the transport (and subsequently the argo FD)
  associated with the NDVM that just shut down.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>