### PR TITLE
Revert "OXT-1824 [network-daemon] Close FDs when ndvm is stopped"

### DIFF
--- a/nwd/Main.hs
+++ b/nwd/Main.hs
@@ -29,7 +29,7 @@ import System.Directory
 import System.Process
 
 import Rpc
-import Rpc.Core (getConn)
+import Rpc.Core
 import App
 import Error
 import Tools.Log
@@ -74,8 +74,6 @@ import qualified Rpc.Autogen.NetworkSlaveClient as NWS
 import qualified Rpc.Autogen.NetworkClient as NC
 import Rpc.Autogen.NetworkDaemonConst
 import Rpc.Autogen.NetworkConst
-
-import qualified Network.DBus.Actions as D
 
 -- Main
 main :: IO ()
@@ -142,6 +140,7 @@ onNetworkSignal domid msgname action =
     let rule = matchSignal "com.citrix.xenclient.network.notify" msgname
     in
       nwsOnSignal domid rule action
+
 
 nwdRootObjPath = fromString nwdRootObj
 
@@ -568,25 +567,11 @@ ndvmStatusUpdate uuid domid status = do
                         liftRpc $ do
                             cleanupSlaveObjs appState uuidU domidI 
                             configClearFirewallRules uuidU
-                        closeFds
                          
         | otherwise -> return ()
     where backendObj = networkBackendObj uuidU
           uuidU = fromString uuid
           domidI = fromIntegral domid
-          closeFds = do
-            ctx <- liftRpc $ rpcGetContext
-            clients <- liftIO $ readMVar $ domUClients ctx
-            appState <- getAppState
-            nwses <- liftIO $ readMVar $ nwsInfo appState
-            case (M.lookup (fromString uuid) nwses) of
-              Nothing -> do info $ "Couldn't find nwsInfo"
-                            return ()
-              Just nws -> do
-                case (M.lookup (networkBackendDomid nws) clients) of
-                  Nothing -> do info $ "Couldn't find Dispatcher"
-                                return ()
-                  Just disp -> liftIO $ D.busClose $ getConn disp
 
 listNetworkBackends :: App ([String])
 listNetworkBackends = do 

--- a/nwd/network-daemon.cabal
+++ b/nwd/network-daemon.cabal
@@ -28,7 +28,6 @@ Executable network-daemon
     xchxenstore,
     xchdb,
     xch-rpc,
-    udbus,
     directory
   Main-Is: Main.hs
   GHC-Options -O2 -fwarn-incomplete-patterns -dynamic -threaded


### PR DESCRIPTION
This reverts commit 9399c3ed281dd6393a545cb623a2d6816a3621cf.

There is an issue when ndvm's are destroyed that causes network-daemon
to close a FD but still attempt to use it after it's been closed.
This causes network-daemon to hang, and the end result is that it is
unresponsive to dbus commands until it is killed and restarted.

This was not observed when ndvm's are shutdown normally.

Until this issue is resolved, revert this commit to prevent any
regressions.