### PR TITLE
network-daemon: Dont run udhcpc

### DIFF
--- a/nwd/Main.hs
+++ b/nwd/Main.hs
@@ -151,18 +151,6 @@ configureVirtualInterface appState domid devid mac = liftIO $ void $ do
     (_, _, _, pid) <- createProcess (proc "/usr/sbin/xl" ["network-attach", "0", "type=vif", printf "mac=%s" mac, printf "backend=%s" (show domid)]){ close_fds = True }
     waitForProcess pid
 
-configureDom0IP = do
-    -- assuming that at any given time, dom0 in XT will have only one active interface
-    (exitCode, _,_) <- readProcessWithExitCode_closeFds "ifconfig" ["eth0"] []
-    case exitCode of
-	 ExitSuccess -> do debug "Configure IP address for dom0 interface"
-                           pid <- strip <$> fromMaybe "" <$> maybeGetContents udhcpcPidFile
-                           unless (null pid) $ void $ system $ "kill " ++ pid 
-			   system $ printf "udhcpc -b -i eth0 -p %s" udhcpcPidFile
-	 otherwise -> do threadDelay 1000
-			 configureDom0IP
-    where udhcpcPidFile = "/var/run/udhcpc.pid"
-  
 -- Handler for networkslave_up signal
 -- This is the first signal from the slave. Configure all the networks
 -- exported by the slave and  map the networks as network daemon networks
@@ -253,7 +241,6 @@ newBackendVif appState dbusid domid uuid path args = do
                             debug $ printf "Move %s to %s network" vif (show $ nw)
 			    --withNetworkSlave domid (NWS.comCitrixXenclientNetworkslaveMoveVifToNetwork slaveService slaveRootObj vif (nwsObj nw))
                             addVifToNetwork domid uuid (read guestDomid :: Int) vif (nwsObj nw)
-                            when ((read guestDomid :: Int32) == 0) $ void $ liftIO $ configureDom0IP 
                             syncVifState domid (read guestDomid) devid nw
 
              	          Nothing -> return ()


### PR DESCRIPTION
network-daemon leaks FDs when it runs udhcpc.  These are seen as:
avc:  denied  { read write } for  pid=1974 comm="udhcpc" path="socket:[15201]" dev="sockfs" ino=15201 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:system_r:network_daemon_t:s0 tclass=unix_stream_socket permissive=0
avc:  denied  { read write } for  pid=1974 comm="udhcpc" path="/dev/argo_stream" dev="devtmpfs" ino=14802 scontext=system_u:system_r:dhcpc_t:s0 tcontext=system_u:object_r:argo_t:s0 tclass=chr_file permissive=0

Those started after commit 836c400fa5e3 "Use system call instead of
spawning a shell", but that commit does fix an issue where dom0 doesn't
get an IP (udhcpc doesn't start).

Side-step this issue but removing launch of udhcpc.  Dom0 will run
ifplugd to start it instead.

network-daemon starts udhcpc as:
udhcpc -b -i eth0 -p /var/run/udhcpc.pid
and ifup uses:
/sbin/udhcpc -R -b -p /var/run/udhcpc.eth0.pid -i eth0

So we gain -R - "Release IP on exit".

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>