### PR TITLE
nws: Fix transparent-bridging mode

### DIFF
--- a/nws/NetworkInterface.hs
+++ b/nws/NetworkInterface.hs
@@ -670,6 +670,15 @@ configGetNmConfig key = do
     return $ strip value
     where path = "/" ++ key
 
+setNmConfigUnmanaged :: IO ()
+setNmConfigUnmanaged = do
+      readProcessOrDie "sed" args []
+      return ()
+    where
+      args = ["-i",
+              "/^unmanaged-devices.*/s//unmanaged-devices=*/",
+              nmConfFile]
+
 nmManagesDevices :: IO Bool
 nmManagesDevices = (/= "all") <$> configGetNmConfig eCONFIG_NM_UNMANAGED_DEVICES
 
@@ -683,8 +692,7 @@ updateNmConfig = do
     copyFile "/usr/share/xenclient/nm_scripts/NetworkManager.conf" nmConfFile
     m <- nmManagesDevices
     if not m
-       then do phyMacs <- (mapM interfaceMac) =<< listPhyInterfaces
-               appendFile nmConfFile $ printf "[keyfile]\nunmanaged-devices=%s\n" (concatMap (formatMac) phyMacs)
+       then do setNmConfigUnmanaged
        else return () -- TODO when set unmanaged property is enabled for network objects, update NM conf accordingly
 
     -- create necessary folders needed by network manager 


### PR DESCRIPTION
Transparent bridging currently has issues.  The most notable one is
dom0's vif0.0.  It is initially attached to brbridged - long enough to
get an IP.  However a little while later NetworkManager disconnects the
vif from the bridge.  It looks like NetworkManager tries to dhcp an
address from dom0.  That times out and then NetworkManager detaches
vif0.0 from the bridge.

vif0.0 should not be managed by NM, and it isn't when
trasparent-bridging is not in use.

The current transparent bridge code tries to set unmanaged-devices=mac*
of all physical interfaces.  unmanaged-devices had been unsed until
xenclient-oe commit 374cd7699d3b "Networkmanager: Fix issues related to
devices managed" started setting it.  This mac address doesn't seem to
match properly - eth0 & brbridged are showed as managed along with all
the other br* bridges.

Change the code so that trasparent-bridging is enabled, NetworkManager
doesn't manage any interfaces.  This keeps NetworkManger from messing
with the bridges or interfaces and seems to match expectations for
transparent bridging.

---
Does this approach seem okay?  It's a little silly to sed the config file, but it does the job.

NetworkManager has a DBus API - it would have been nice if network-slave were written to configured it over DBus.