### PR TITLE
network-slave: Wait to grab iptables lock

### DIFF
--- a/nws/NetworkFirewall.hs
+++ b/nws/NetworkFirewall.hs
@@ -80,7 +80,7 @@ domidToUuid domid =
 
 addForwardChain :: String -> String -> String -> IO ()
 addForwardChain inputIf outputIf interface = do 
-    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-S", "FORWARD"] []
+    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-w", "-S", "FORWARD"] []
     let output = lines out
     configGetBridgeFiltering >>= \x -> when (x && outputIf /= interface) $ 
          addIptableRulesIfMissing output (printf "-A FORWARD -i %s -o %s -m physdev --physdev-in %s -j FORWARD_%s" outputIf outputIf interface outputIf)
@@ -97,7 +97,7 @@ addForwardChain inputIf outputIf interface = do
 cleanupFirewallRules vif bridgeI = configGetBridgeFiltering >>= \x -> when (x) $ do
     bridge <- if (null bridgeI) 
                  then do
-                    out <- words <$> (spawnShell $ printf "iptables -L FORWARD -v | grep %s | awk '{ print $6 }'" vif)
+                    out <- words <$> (spawnShell $ printf "iptables -w -L FORWARD -v | grep %s | awk '{ print $6 }'" vif)
                     if (null out) then return "" else return $ head out
                  else return bridgeI
 
@@ -186,13 +186,13 @@ applyFirewallRules vif bridge = void $ configGetBridgeFiltering >>= \x -> when x
 
 appendRuleIfMissing :: String -> String -> IO ()
 appendRuleIfMissing table ruleArgs = do
-    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-S", table] []
+    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-w", "-S", table] []
     addIptableRulesIfMissing (lines out) rule
     where rule = printf " -A %s %s" table ruleArgs
 
 insertRuleIfMissing :: String -> String -> IO ()
 insertRuleIfMissing table ruleArgs = do
-    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-S", table] []
+    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-w", "-S", table] []
     addIptableRulesIfMissing (lines out) rule
     where rule = printf " -I %s %s" table ruleArgs
 

--- a/nws/NetworkForwarding.hs
+++ b/nws/NetworkForwarding.hs
@@ -76,14 +76,14 @@ initNATRules = do
     return ()
 
     where 
-        natRuleAdd prefix = spawnShell $ printf "iptables -t nat -A POSTROUTING -o %s+ -j MASQUERADE" prefix
+        natRuleAdd prefix = spawnShell $ printf "iptables -w -t nat -A POSTROUTING -o %s+ -j MASQUERADE" prefix
 
 cleanupNATRules :: IO ()
-cleanupNATRules = void $ spawnShell "iptables -t nat -F POSTROUTING"
+cleanupNATRules = void $ spawnShell "iptables -w -t nat -F POSTROUTING"
 
 addNATMasqueradeRule :: String -> IO ()
 addNATMasqueradeRule outputIf = do
-    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-t", "nat", "-S"] []
+    (_, out, _) <- readProcessWithExitCode_closeFds "/usr/sbin/iptables" ["-w", "-t", "nat", "-S"] []
     addIptableRulesIfMissing (lines out) masqRule
     where
         masqRule = printf "-t nat -A POSTROUTING -o %s+ -j MASQUERADE" outputIf

--- a/nws/NetworkUtils.hs
+++ b/nws/NetworkUtils.hs
@@ -178,7 +178,7 @@ disableBridgeNetfilter = void $ do
 
 logAndExecuteIptables cmd = void $ do
     debug cmd
-    spawnShell $ "iptables " ++ cmd
+    spawnShell $ "iptables -w " ++ cmd
 
 bridgeExists :: String -> IO Bool
 bridgeExists bridge = doesDirectoryExist (sysfsnet </> bridge </> "brif")
@@ -273,7 +273,7 @@ addIptableRulesIfMissing iptablesOut iptablesArgs = do
     unless (any (match iptablesArgs) iptablesOut) $ do
         (exitCode, _,err) <- do
                      debug $ "iptables " ++ iptablesArgs
-                     readProcessWithExitCode_closeFds "iptables" (words iptablesArgs) []
+                     readProcessWithExitCode_closeFds "iptables" (["-w"] ++ words iptablesArgs) []
         case exitCode of
              ExitSuccess -> return ()
              _ -> error $ printf "cannot add rule %s : %s" iptablesArgs err


### PR DESCRIPTION
iptables fails operations when it can't grab its lock - this seems like it can be fatal to further operations of network-slaves if chains are not created.

This was observed which may be a result of a failed iptables command not creating FORWARD_brbridged:
network-slave: exception: "cannot add rule -A FORWARD -i brbridged -o brbridged -m physdev --physdev-in eth0 -j FORWARD_brbridged : iptables v1.8.4 (legacy): Couldn't load target FORWARD_brbridged':No such file or directory\n\nTry iptables -h' or 'iptables --help' for more information.\n" while processing RPC "configure"

Make all iptables invocations use `-w` to wait for the lock.